### PR TITLE
Adjust dependencies

### DIFF
--- a/Script/install.sh
+++ b/Script/install.sh
@@ -25,8 +25,8 @@ install_dependencies() {
     sudo apt-get install nodejs -y
 
   	sudo apt-get install git libi2c-dev i2c-tools arduino minicom -y
-    sudo apt-get install python-pip  python-smbus  python-dev  python-serial  python-rpi.gpio  python-scipy  python-numpy -y
-    sudo apt-get install python3-pip python3-smbus python3-dev python3-serial python3-rpi.gpio python3-scipy python3-numpy -y
+    sudo apt-get install python-pip  python-smbus  python-dev  python-serial  python-rpi.gpio  python-scipy -y
+    sudo apt-get install python3-pip python3-smbus python3-dev python3-serial python3-rpi.gpio python3-scipy -y
 
     feedback "Dependencies for the GrovePi installed"
 }

--- a/Software/Python/grove_dht_pro_filter/grove_dht.py
+++ b/Software/Python/grove_dht_pro_filter/grove_dht.py
@@ -1,5 +1,5 @@
 import threading # we need threads for processing data seperately from the main thread
-import numpy # for statistical computations
+import statistics as stats # for statistical computations
 import datetime
 import math # for NaNs
 from grovepi import dht # we built on top of the base function found in the grovepi library
@@ -16,8 +16,8 @@ def statisticalNoiseReduction(values, std_factor_threshold = 2):
 	if len(values) == 0:
 		return []
 
-	mean = numpy.mean(values)
-	standard_deviation = numpy.std(values)
+	mean = stats.mean(values)
+	standard_deviation = stats.stdev(values, mean)
 
 	# just return if we only got constant values
 	if standard_deviation == 0:
@@ -187,8 +187,8 @@ class Dht(threading.Thread):
 
 			if len(values) > 0:
 				# remove outliers
-				temp = numpy.mean(statisticalNoiseReduction([x["temp"] for x in values], self.filtering_aggresiveness))
-				humidity = numpy.mean(statisticalNoiseReduction([x["hum"] for x in values], self.filtering_aggresiveness))
+				temp = stats.mean(statisticalNoiseReduction([x["temp"] for x in values], self.filtering_aggresiveness))
+				humidity = stats.mean(statisticalNoiseReduction([x["hum"] for x in values], self.filtering_aggresiveness))
 
 				# insert into the filtered buffer
 				self.lock.acquire()

--- a/Software/Python/grove_hightemperature_sensor/grove_hightemperature_sensor.py
+++ b/Software/Python/grove_hightemperature_sensor/grove_hightemperature_sensor.py
@@ -1,7 +1,6 @@
 import grovepi
 import math
 import json
-import numpy as np
 from scipy.interpolate import interp1d
 
 # Library written for Python 3!

--- a/Software/Python/grove_mini_motor_driver/grove_mini_motor_driver.py
+++ b/Software/Python/grove_mini_motor_driver/grove_mini_motor_driver.py
@@ -15,7 +15,10 @@ def getNewSMBus():
         import winrt_smbus as smbus
         bus = smbus.SMBus(1)
     else:
-        import smbus
+        try:
+            import smbus
+        except:
+            import smbus2 as smbus
         import RPi.GPIO as GPIO
         revision = GPIO.RPI_REVISION
 

--- a/Software/Python/grovepi.py
+++ b/Software/Python/grovepi.py
@@ -46,8 +46,8 @@ THE SOFTWARE.
 import sys
 import time
 import math
+import statistics as stats
 import struct
-import numpy
 from periphery import I2C, I2CError
 
 debug = 0
@@ -373,8 +373,8 @@ def statisticalNoiseReduction(values, std_factor_threshold = 2):
 	if len(values) == 0:
 		return []
 
-	mean = numpy.mean(values)
-	standard_deviation = numpy.std(values)
+	mean = stats.mean(values)
+	standard_deviation = stats.stdev(values, mean)
 
 	if standard_deviation == 0:
 		return values

--- a/Software/Python/setup.py
+++ b/Software/Python/setup.py
@@ -69,5 +69,5 @@ setuptools.setup(
     keywords = ['robot', 'grovepi', 'grovepi+', 'dexter industries', 'learning', 'education', 'iot', 'internet of things', 'prototyping'],
 
     py_modules = ['grovepi'],
-    install_requires = ['numpy', 'python-periphery']
+    install_requires = ['python-periphery']
 )


### PR DESCRIPTION
GrovePi had a dependency on numpy, which made the install take forever on the poor RaspPi (~10 minutes). It looks like numpy was only used to calculate mean and stddev, which are both available in the `statistics` standard module. It is a Python3-only module, but I think that's ok for us. With no numpy dependency, the install takes a few seconds.

Unrelatedly, there is some issue between smbus and Python3.6, and it failed to install for me. smbus2 is a pure-Python drop-in replacement for smbus, and it seemed to install and work fine. So this PR makes the motor driver we use fall back to smbus2 if smbus is not available. Note that this is not an issue in the main grovepi sensor driver file, since they use a module called `periphery`. I could have used that in the motor driver, but I opted for the drop-in replacement to avoid other code changes.